### PR TITLE
first pass at map command

### DIFF
--- a/commands/util/maps.js
+++ b/commands/util/maps.js
@@ -1,0 +1,38 @@
+const Commando = require('discord.js-commando'),
+  {CommandGroup} = require('../../app/constants'),
+  {oneLine} = require('common-tags'),
+  private_settings = require('../../data/private-settings'),
+  Helper = require('../../app/helper');
+
+class MapCommand extends Commando.Command  {
+  constructor(client) {
+    super(client, {
+      name: 'maps',
+      group: CommandGroup.UTIL,
+      memberName: 'maps',
+      aliases: ['map'],
+      description: 'Displays the url to the map used for regions',
+      details: oneLine`
+				This server uses a third party map to define what the various regions are. This
+				command will share the current url to the map for ease of use
+			`,
+      examples: ['\t!maps'],
+    });
+  }
+
+  async run(message, args) {
+    // We don't load this command unless the region_map_link is defined, so it's safe for
+    // use to assume it exists
+    const url = private_settings.region_map_link;
+
+    const messages = [];
+    try {
+      messages.push(await message.direct(url));
+      if (message.channel.type !== 'dm') messages.push(await message.reply(Helper.getText('region_map_dm.success', message)));
+    } catch (err) {
+      messages.push(await message.reply(Helper.getText('region_map_dm.warning', message)));
+    }
+  }
+}
+
+module.exports = MapCommand;

--- a/data/private-settings.json.default
+++ b/data/private-settings.json.default
@@ -7,6 +7,7 @@
   "github_user": "",
   "github_password": "",
   "google_api_key": "",
+  "region_map_link": "",
   "db": {
     "host": "localhost",
     "user": "root",

--- a/data/text.json
+++ b/data/text.json
@@ -38,5 +38,9 @@
   "status": {
     "warning": "Check the status of raids from a regional or raid channel!"
   },
-  "channel_deletion_warning": "**WARNING**: This channel will self-destruct ${time_until_deletion}!"
+  "channel_deletion_warning": "**WARNING**: This channel will self-destruct ${time_until_deletion}!",
+  "region_map_dm": {
+    "success": "Sent you a DM with the link.",
+    "warning": "Unable to send you the DM. You probably have DMs disabled."
+  }
 }

--- a/index.js
+++ b/index.js
@@ -120,6 +120,12 @@ Client.registry.registerCommands([
   require('./commands/util/help')
 ]);
 
+if (private_settings.region_map_link !== '') {
+  Client.registry.registerCommand(
+    require('./commands/util/maps')
+  )
+}
+
 if (private_settings.google_api_key !== '') {
   Client.registry.registerCommand(
     require('./commands/util/find-region'));


### PR DESCRIPTION
Creates new key in private-settings, 'region_map_url'.  If this is defined,
adds the map command, which will dm a user the url to the value defined in
key.

I'm not sure if private_settings is the right place for the url def, or if it belongs in
settings.json instead.  Also text.json didn't seem to be used in a lot of places but
it seemed to be the best place for string constants, I can move them if there's a 
better location.